### PR TITLE
feat: basisDatenklassen + Städteverteilung nach Kontinenten inkl. Unit-Tests

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/logic/CityDistributer.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/logic/CityDistributer.kt
@@ -1,0 +1,42 @@
+package at.aau.serg.websocketbrokerdemo.logic
+
+import at.aau.serg.websocketbrokerdemo.models.City
+import at.aau.serg.websocketbrokerdemo.models.Continent
+import at.aau.serg.websocketbrokerdemo.models.Player
+
+class CityDistributor {
+
+    /**
+     * Verteil-Logik: Jeder Spieler bekommt eine bestimmte Anzahl an Karten
+     * pro Kontinent (Stapel), um eine faire Weltreise zu garantieren.
+     * * @param allCities Die Liste aller verfügbaren Städte (ungemischt).
+     * @param players Die Liste der Spieler.
+     * @param amountPerContinent Wie viele Karten jeder Spieler AUS JEDEM Kontinent erhalten soll.
+     */
+    fun distributeByContinent(allCities: List<City>, players: List<Player>, amountPerContinent: Int) {
+        if (players.isEmpty() || allCities.isEmpty()) return
+
+        // 1. Gruppiere alle Städte nach Kontinent und mische die einzelnen Stapel
+        val continentPools: Map<Continent, MutableList<City>> = allCities
+            .groupBy { it.continent }
+            .mapValues { (_, cities) -> cities.shuffled().toMutableList() }
+
+        // 2. Gehe jeden Spieler durch
+        for (player in players) {
+            // 3. Gehe jeden Kontinent-Stapel durch
+            for (continent in Continent.values()) {
+                val currentPool = continentPools[continent]
+
+                if (currentPool != null) {
+                    // Ziehe n Karten für diesen Spieler aus diesem Kontinent
+                    repeat(amountPerContinent) {
+                        if (currentPool.isNotEmpty()) {
+                            val pickedCity = currentPool.removeAt(0)
+                            player.ownedCities.add(pickedCity)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/models/City.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/models/City.kt
@@ -1,0 +1,6 @@
+package at.aau.serg.websocketbrokerdemo.models
+
+data class City(
+    val name: String,
+    val continent: Continent
+)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/models/Continent.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/models/Continent.kt
@@ -1,0 +1,11 @@
+package at.aau.serg.websocketbrokerdemo.models
+
+enum class Continent {
+    AFRICA,
+    ASIA,
+    EUROPE,
+    NORTH_AMERICA,
+    SOUTH_AMERICA,
+    OCEANIA,
+    ANTARCTICA
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/models/Player.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/models/Player.kt
@@ -1,0 +1,8 @@
+package at.aau.serg.websocketbrokerdemo.models
+
+data class Player(
+    val name: String,
+    // Wir nutzen eine MutableList, damit wir später im Spiel
+    // Städte hinzufügen oder entfernen können (z.B. durch Eroberung)
+    val ownedCities: MutableList<City> = mutableListOf()
+)

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/logic/CityDistributorTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/logic/CityDistributorTest.kt
@@ -1,0 +1,95 @@
+package at.aau.serg.websocketbrokerdemo
+
+import at.aau.serg.websocketbrokerdemo.logic.CityDistributor
+import at.aau.serg.websocketbrokerdemo.models.City
+import at.aau.serg.websocketbrokerdemo.models.Continent
+import at.aau.serg.websocketbrokerdemo.models.Player
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CityDistributorTest {
+
+    private lateinit var distributor: CityDistributor
+    private lateinit var players: List<Player>
+    private lateinit var testCities: List<City>
+
+    @BeforeEach
+    fun setup() {
+        distributor = CityDistributor()
+
+        // 3 Spieler für test
+        players = listOf(
+            Player("Alice"),
+            Player("Bob"),
+            Player("Charlie")
+        )
+
+        //  Liste: 4 Kontinente mit je 6 Städten
+        testCities = listOf<City>(
+            // Europa (6)
+            City("Wien", Continent.EUROPE), City("Berlin", Continent.EUROPE),
+            City("Paris", Continent.EUROPE), City("Rom", Continent.EUROPE),
+            City("Madrid", Continent.EUROPE), City("London", Continent.EUROPE),
+
+            // Asien (6)
+            City("Tokio", Continent.ASIA), City("Peking", Continent.ASIA),
+            City("Bangkok", Continent.ASIA), City("Seoul", Continent.ASIA),
+            City("Neu-Delhi", Continent.ASIA), City("Singapur", Continent.ASIA),
+
+            // Nordamerika (6)
+            City("New York", Continent.NORTH_AMERICA), City("Los Angeles", Continent.NORTH_AMERICA),
+            City("Toronto", Continent.NORTH_AMERICA), City("Chicago", Continent.NORTH_AMERICA),
+            City("Mexiko-Stadt", Continent.NORTH_AMERICA), City("Miami", Continent.NORTH_AMERICA),
+
+            // Südamerika (6)
+            City("Rio de Janeiro", Continent.SOUTH_AMERICA), City("Buenos Aires", Continent.SOUTH_AMERICA),
+            City("Lima", Continent.SOUTH_AMERICA), City("Bogota", Continent.SOUTH_AMERICA),
+            City("Santiago", Continent.SOUTH_AMERICA), City("Quito", Continent.SOUTH_AMERICA)
+        )
+    }
+
+    @Test
+    fun `test distributeByContinent gives correct amount for multiple players`() {
+        // Normalfall: Jeder zieht 2 Karten pro Kontinent
+        distributor.distributeByContinent(testCities, players, 2)
+
+        for (player in players) {
+            assertEquals(8, player.ownedCities.size, "${player.name} sollte genau 8 Städte haben")
+
+            val europeCount = player.ownedCities.count { it.continent == Continent.EUROPE }
+            val asiaCount = player.ownedCities.count { it.continent == Continent.ASIA }
+            val naCount = player.ownedCities.count { it.continent == Continent.NORTH_AMERICA }
+            val saCount = player.ownedCities.count { it.continent == Continent.SOUTH_AMERICA }
+
+            assertEquals(2, europeCount, "${player.name} hat nicht 2 in Europa")
+            assertEquals(2, asiaCount, "${player.name} hat nicht 2 in Asien")
+            assertEquals(2, naCount, "${player.name} hat nicht 2 in Nordamerika")
+            assertEquals(2, saCount, "${player.name} hat nicht 2 in Südamerika")
+        }
+    }
+
+    @Test
+    fun `test gracefully handles not enough cities in a pool`() {
+        // Randfall 1: Zu wenige Städte
+        val fewCities = listOf(City("Wien", Continent.EUROPE))
+
+        distributor.distributeByContinent(fewCities, players, 2)
+
+        assertEquals(1, players[0].ownedCities.size, "Alice sollte die einzige verfügbare Stadt bekommen")
+        assertEquals(0, players[1].ownedCities.size, "Bob sollte leer ausgehen")
+        assertEquals(0, players[2].ownedCities.size, "Charlie sollte leer ausgehen")
+    }
+
+    @Test
+    fun `test handles empty city list without crashing`() {
+        // Randfall 2: Gar keine Städte
+        val emptyCities = emptyList<City>()
+
+        distributor.distributeByContinent(emptyCities, players, 2)
+
+        for (player in players) {
+            assertEquals(0, player.ownedCities.size, "${player.name} sollte keine Städte haben")
+        }
+    }
+}


### PR DESCRIPTION
Datenklassen für Spieler, Städte und Kontinente als Basis für die Spiellogik erstellt

### Was wurde gemacht?
- Die `CityDistributor`-Klasse wurde um die Logik erweitert, Städte fair und nach Kontinenten getrennt an die Spieler zu verteilen.
- Die Verteilung verhindert, dass Spieler zufällig nur Städte auf einem einzigen Kontinent erhalten 
- Umfassende Unit-Tests für den `CityDistributor` geschrieben, inklusive Überprüfung des Normalfalls (Happy Path) und von Randfällen (leere Listen, zu wenige Städte im Pool).

### Verknüpfte Issues:
Closes #16
Closes #17
Closes #18 