### PR TITLE
feat: multiplayer dice rolling with turn-based UI

### DIFF
--- a/app/src/main/java/MyStomp.kt
+++ b/app/src/main/java/MyStomp.kt
@@ -209,6 +209,33 @@ class MyStomp(val callbacks: Callbacks) {
         }
     }
 
+    fun rollDice(lobbyId: String, playerId: String) {
+        scope.launch {
+            try {
+                val command = JSONObject()
+                command.put("type", "ROLL_DICE")
+                command.put("playerId", playerId)
+                session?.sendText("/app/lobby/$lobbyId/command", command.toString())
+            } catch (e: Exception) {
+                Log.e("MyStomp", "Fehler beim Würfeln", e)
+            }
+        }
+    }
+
+    fun endTurn(lobbyId: String, playerId: String, diceValue: Int) {
+        scope.launch {
+            try {
+                val command = JSONObject()
+                command.put("type", "MOVE_TOKEN")
+                command.put("playerId", playerId)
+                command.put("moveSteps", diceValue)
+                session?.sendText("/app/lobby/$lobbyId/command", command.toString())
+            } catch (e: Exception) {
+                Log.e("MyStomp", "Fehler beim Zug beenden", e)
+            }
+        }
+    }
+
     fun disconnect() {
         scope.launch {
             try {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -35,6 +35,12 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
     private val _gameMode = MutableStateFlow("Grand Tour")
     val gameMode: StateFlow<String> = _gameMode.asStateFlow()
 
+    private val _diceValue = MutableStateFlow<Int?>(null)
+    val diceValue: StateFlow<Int?> = _diceValue.asStateFlow()
+
+    private val _currentTurnPlayerId = MutableStateFlow<String?>(null)
+    val currentTurnPlayerId: StateFlow<String?> = _currentTurnPlayerId.asStateFlow()
+
     fun setGameMode(mode: String) {
         _gameMode.value = mode
     }
@@ -87,6 +93,15 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
         stomp.startGameCmd(_lobbyId.value, stops)
     }
 
+    fun onRollDice() {
+        stomp.rollDice(_lobbyId.value, _playerName.value)
+    }
+
+    fun onEndTurn() {
+        val dice = _diceValue.value ?: return
+        stomp.endTurn(_lobbyId.value, _playerName.value, dice)
+    }
+
     fun leaveLobby() {
         val currentLobbyId = _lobbyId.value
         val currentPlayerName = _playerName.value
@@ -129,6 +144,10 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
                         }
                         _playersList.value = newList
                     }
+
+                    // Würfelergebnis und aktueller Spieler aktualisieren
+                    _diceValue.value = if (stateJson.isNull("lastDiceValue")) null else stateJson.optInt("lastDiceValue")
+                    _currentTurnPlayerId.value = stateJson.optString("currentPlayerId").ifEmpty { null }
 
                     // Navigation basierend auf Phase und Command-Type
                     val commandType = rootJson.optString("commandType", "")

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
@@ -153,10 +153,10 @@ fun GameScreen(viewModel: AppViewModel) {
             }
         }
 
-        // Warte-Hinweis wenn nicht dein Zug
-        if (!isMyTurn && currentTurnPlayerId != null) {
+        // Hinweis wessen Zug es ist
+        if (currentTurnPlayerId != null) {
             Text(
-                text = "Warte auf $currentTurnPlayerId ...",
+                text = if (isMyTurn) "Du bist dran!" else "Warte auf $currentTurnPlayerId ...",
                 color = Color.White,
                 fontSize = 13.sp,
                 modifier = Modifier

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
@@ -14,7 +14,11 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
 import androidx.compose.runtime.*
+import androidx.compose.ui.draw.alpha
+import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -56,6 +60,22 @@ fun GameScreen(viewModel: AppViewModel) {
 
     //Bucketlist offen? Default false
     var showBucketListDialog by remember { mutableStateOf(false) }
+
+    // Würfelergebnis fade-out nach 5 Sekunden
+    var showDiceOverlay by remember { mutableStateOf(false) }
+    val diceAlpha = remember { Animatable(0f) }
+    LaunchedEffect(diceValue) {
+        if (diceValue != null) {
+            showDiceOverlay = true
+            diceAlpha.snapTo(1f)
+            delay(4000)
+            diceAlpha.animateTo(0f, animationSpec = tween(1000))
+            showDiceOverlay = false
+        } else {
+            showDiceOverlay = false
+            diceAlpha.snapTo(0f)
+        }
+    }
 
     // Box (Schichten-Design)
     Box(
@@ -107,11 +127,12 @@ fun GameScreen(viewModel: AppViewModel) {
             }
         }
 
-        // Würfelergebnis – für alle sichtbar in der Mitte
-        if (diceValue != null) {
+        // Würfelergebnis – für alle sichtbar in der Mitte, verschwindet nach 5s
+        if (showDiceOverlay && diceValue != null) {
             Box(
                 modifier = Modifier
                     .align(Alignment.Center)
+                    .alpha(diceAlpha.value)
                     .background(Color(0xCC000000), RoundedCornerShape(20.dp))
                     .padding(horizontal = 32.dp, vertical = 20.dp),
                 contentAlignment = Alignment.Center

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
@@ -68,7 +68,7 @@ fun GameScreen(viewModel: AppViewModel) {
         if (diceValue != null) {
             showDiceOverlay = true
             diceAlpha.snapTo(1f)
-            delay(4000)
+            delay(2000)
             diceAlpha.animateTo(0f, animationSpec = tween(1000))
             showDiceOverlay = false
         } else {
@@ -122,7 +122,8 @@ fun GameScreen(viewModel: AppViewModel) {
                     name = displayName,
                     bucketListCount = 8, // TODO: Später vom Server holen
                     avatar = avatar,
-                    isActive = playerName == currentTurnPlayerId
+                    isActive = playerName == currentTurnPlayerId,
+                    diceValue = if (playerName == currentTurnPlayerId) diceValue else null
                 )
             }
         }
@@ -249,7 +250,7 @@ fun GameScreen(viewModel: AppViewModel) {
 //Hilfe damit App nicht abstürzt (bsp. derzeit noch fehlende Bilder)
 
 @Composable
-fun PlayerCard(name: String, bucketListCount: Int, avatar: ImageBitmap?, isActive: Boolean) {
+fun PlayerCard(name: String, bucketListCount: Int, avatar: ImageBitmap?, isActive: Boolean, diceValue: Int? = null) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.height(50.dp)
@@ -280,7 +281,13 @@ fun PlayerCard(name: String, bucketListCount: Int, avatar: ImageBitmap?, isActiv
                 )
                 .padding(start = 24.dp, end = 16.dp, top = 4.dp, bottom = 4.dp)
         ) {
-            Text(text = name, fontSize = 12.sp, color = Color(0xFF1E56A0), fontWeight = FontWeight.Bold)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = name, fontSize = 12.sp, color = Color(0xFF1E56A0), fontWeight = FontWeight.Bold)
+                if (diceValue != null) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(text = "🎲 $diceValue", fontSize = 11.sp, color = Color(0xFFD4AF37), fontWeight = FontWeight.Bold)
+                }
+            }
             Text(text = "Bucket List: $bucketListCount", fontSize = 10.sp, color = Color.Gray)
         }
     }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
@@ -35,6 +35,11 @@ fun GameScreen(viewModel: AppViewModel) {
     val playersList by viewModel.playersList.collectAsState()
     val currentPlayerName by viewModel.playerName.collectAsState()
     val gameMode by viewModel.gameMode.collectAsState()
+    val diceValue by viewModel.diceValue.collectAsState()
+    val currentTurnPlayerId by viewModel.currentTurnPlayerId.collectAsState()
+    val isMyTurn = currentTurnPlayerId == currentPlayerName
+    val canRoll = isMyTurn && diceValue == null
+    val canEndTurn = isMyTurn && diceValue != null
 
     //Bilder
     val mapBitmap = loadAssetBitmap(context, "world_map_klein.png")
@@ -97,9 +102,48 @@ fun GameScreen(viewModel: AppViewModel) {
                     name = displayName,
                     bucketListCount = 8, // TODO: Später vom Server holen
                     avatar = avatar,
-                    isActive = playerName == currentPlayerName
+                    isActive = playerName == currentTurnPlayerId
                 )
             }
+        }
+
+        // Würfelergebnis – für alle sichtbar in der Mitte
+        if (diceValue != null) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .background(Color(0xCC000000), RoundedCornerShape(20.dp))
+                    .padding(horizontal = 32.dp, vertical = 20.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "$diceValue",
+                        fontSize = 72.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+                    Text(
+                        text = if (isMyTurn) "Dein Wurf!" else "$currentTurnPlayerId würfelt",
+                        fontSize = 14.sp,
+                        color = Color(0xFFD4AF37)
+                    )
+                }
+            }
+        }
+
+        // Warte-Hinweis wenn nicht dein Zug
+        if (!isMyTurn && currentTurnPlayerId != null) {
+            Text(
+                text = "Warte auf $currentTurnPlayerId ...",
+                color = Color.White,
+                fontSize = 13.sp,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 16.dp)
+                    .background(Color(0x88000000), RoundedCornerShape(8.dp))
+                    .padding(horizontal = 16.dp, vertical = 6.dp)
+            )
         }
 
         //Actionbuttons
@@ -112,12 +156,22 @@ fun GameScreen(viewModel: AppViewModel) {
             GameButton(
                 text = "ROLL DICE",
                 imageBitmap = diceBitmap,
-                onClick = {
-                    println("WÜRFEL WURDE GEKLICKT!")
-                }
+                enabled = canRoll,
+                onClick = { viewModel.onRollDice() }
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            Spacer(modifier = Modifier.height(1.dp))
+
+            // Zug beenden – nur sichtbar wenn gewürfelt und dran
+            if (canEndTurn) {
+                GameButton(
+                    text = "ZUG ENDE",
+                    imageBitmap = null,
+                    enabled = true,
+                    onClick = { viewModel.onEndTurn() }
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+            }
 
             //Bucket List
             GameButton(
@@ -212,12 +266,13 @@ fun PlayerCard(name: String, bucketListCount: Int, avatar: ImageBitmap?, isActiv
 }
 
 @Composable
-fun GameButton(text: String, imageBitmap: ImageBitmap?, onClick: () -> Unit) {
+fun GameButton(text: String, imageBitmap: ImageBitmap?, onClick: () -> Unit, enabled: Boolean = true) {
+    val bgColor = if (enabled) Color.White.copy(alpha = 0.8f) else Color.Gray.copy(alpha = 0.4f)
     Box(
         modifier = Modifier
             .size(120.dp)
-            .background(Color.White.copy(alpha = 0.8f), RoundedCornerShape(16.dp))
-            .clickable { onClick() }
+            .background(bgColor, RoundedCornerShape(16.dp))
+            .then(if (enabled) Modifier.clickable { onClick() } else Modifier)
             .padding(12.dp),
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/AppViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/AppViewModelTest.kt
@@ -508,6 +508,115 @@ class AppViewModelTest {
         assertEquals("login", viewModel.currentScreen.value)
     }
 
+    // ========== DICE / TURN TESTS ==========
+
+    @Test
+    fun `diceValue is null initially`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        assertNull(viewModel.diceValue.value)
+    }
+
+    @Test
+    fun `currentTurnPlayerId is null initially`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        assertNull(viewModel.currentTurnPlayerId.value)
+    }
+
+    @Test
+    fun `onRollDice calls stomp rollDice with lobbyId and playerName`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.hostLobby("Alice")
+        val lobbyId = viewModel.lobbyId.value
+
+        viewModel.onRollDice()
+
+        verify { mockStomp.rollDice(lobbyId, "Alice") }
+    }
+
+    @Test
+    fun `onEndTurn calls stomp endTurn with correct dice value`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.hostLobby("Alice")
+        val lobbyId = viewModel.lobbyId.value
+        val response = """{"success":true,"message":"OK","lobbyId":"$lobbyId","commandType":"ROLL_DICE","state":{"lobbyId":"$lobbyId","players":[{"playerId":"Alice"}],"phase":"IN_TURN","currentPlayerId":"Alice","lastDiceValue":4}}"""
+        viewModel.onResponse(response)
+
+        viewModel.onEndTurn()
+
+        verify { mockStomp.endTurn(lobbyId, "Alice", 4) }
+    }
+
+    @Test
+    fun `onEndTurn does nothing when diceValue is null`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        viewModel.onEndTurn()
+
+        verify(exactly = 0) { mockStomp.endTurn(any(), any(), any()) }
+    }
+
+    @Test
+    fun `onResponse parses lastDiceValue from state`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        val response = """{"success":true,"message":"OK","lobbyId":"1234","commandType":"ROLL_DICE","state":{"lobbyId":"1234","players":[{"playerId":"Alice"}],"phase":"IN_TURN","currentPlayerId":"Alice","lastDiceValue":5}}"""
+        viewModel.onResponse(response)
+
+        assertEquals(5, viewModel.diceValue.value)
+    }
+
+    @Test
+    fun `onResponse sets diceValue to null when lastDiceValue is null in JSON`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.onResponse("""{"success":true,"message":"OK","lobbyId":"1234","commandType":"ROLL_DICE","state":{"lobbyId":"1234","players":[{"playerId":"Alice"}],"phase":"IN_TURN","currentPlayerId":"Alice","lastDiceValue":3}}""")
+
+        viewModel.onResponse("""{"success":true,"message":"OK","lobbyId":"1234","commandType":"MOVE_TOKEN","state":{"lobbyId":"1234","players":[{"playerId":"Alice"}],"phase":"IN_TURN","currentPlayerId":"Bob","lastDiceValue":null}}""")
+
+        assertNull(viewModel.diceValue.value)
+    }
+
+    @Test
+    fun `onResponse parses currentPlayerId from state`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        val response = """{"success":true,"message":"OK","lobbyId":"1234","commandType":"START_GAME","state":{"lobbyId":"1234","players":[{"playerId":"Alice"},{"playerId":"Bob"}],"phase":"IN_TURN","currentPlayerId":"Alice"}}"""
+        viewModel.onResponse(response)
+
+        assertEquals("Alice", viewModel.currentTurnPlayerId.value)
+    }
+
+    @Test
+    fun `onResponse updates currentTurnPlayerId after move token`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.onResponse("""{"success":true,"message":"OK","lobbyId":"1234","commandType":"START_GAME","state":{"lobbyId":"1234","players":[{"playerId":"Alice"},{"playerId":"Bob"}],"phase":"IN_TURN","currentPlayerId":"Alice","lastDiceValue":null}}""")
+
+        viewModel.onResponse("""{"success":true,"message":"OK","lobbyId":"1234","commandType":"MOVE_TOKEN","state":{"lobbyId":"1234","players":[{"playerId":"Alice"},{"playerId":"Bob"}],"phase":"IN_TURN","currentPlayerId":"Bob","lastDiceValue":null}}""")
+
+        assertEquals("Bob", viewModel.currentTurnPlayerId.value)
+    }
+
+    @Test
+    fun `onResponse sets currentTurnPlayerId to null when field is empty`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        val response = """{"success":true,"message":"OK","lobbyId":"1234","commandType":"CREATE_LOBBY","state":{"lobbyId":"1234","players":[{"playerId":"Host"}],"phase":"LOBBY"}}"""
+        viewModel.onResponse(response)
+
+        assertNull(viewModel.currentTurnPlayerId.value)
+    }
+
     // ========== HELPER ==========
 
     private fun createViewModelWithMockStomp(mockStomp: MyStomp): AppViewModel {


### PR DESCRIPTION
 ## Zusammenfassung                                                            
                  
  - Rundenbasiertes Würfeln: nur der aktive Spieler kann würfeln, für alle anderen ist der Button deaktiviert
  - Würfelergebnis erscheint mit Fade-out-Animation und wird zusätzlich in der Spielerkarte des aktiven Spielers
  angezeigt                                                                     
  - „ZUG ENDE"-Button erscheint nach dem Würfeln und sendet MOVE_TOKEN an den Server                                                                        
  - Zug-Indikator am unteren Rand zeigt „Du bist dran!" bzw. „Warte auf <name>  …"                                                                            

Closes #36 