### PR TITLE
Zoom und Verschieben der Weltkarte

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
-
+import kotlin.math.pow
 @Composable
 fun GameScreen(viewModel: AppViewModel) {
     val context = LocalContext.current
@@ -176,30 +176,57 @@ fun ZoomableMap(mapBitmap: ImageBitmap) {
     var scale by remember {mutableStateOf(1f)}
     var offset by remember {mutableStateOf(Offset.Zero)}
 
-    Image(
-        bitmap = mapBitmap,
-        contentDescription = "Weltkarte",
-        contentScale = ContentScale.Fit,
-        modifier = Modifier
-            .fillMaxSize()
-            .graphicsLayer(
-                scaleX = scale,
-                scaleY = scale,
-                translationX = offset.x,
-                translationY = offset.y
-            )
-            .pointerInput(Unit) {
-                detectTransformGestures { _, pan, zoom, _ ->
-                    scale = (scale * zoom).coerceIn(1f, 4f)
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        val screenWidth = constraints.maxWidth.toFloat()
+        val screenHeight = constraints.maxHeight.toFloat()
 
-                    if(scale > 1f) {
-                        offset += pan
-                    }else {
-                        offset = Offset.Zero
+
+        Image(
+            bitmap = mapBitmap,
+            contentDescription = "Weltkarte",
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer(
+                    scaleX = scale,
+                    scaleY = scale,
+                    translationX = offset.x,
+                    translationY = offset.y,
+                )
+                .pointerInput(screenWidth, screenHeight) {
+                    detectTransformGestures { _, pan, zoom, _ ->
+                        val adjustedZoom = if (zoom < 1f) {
+                            zoom.toDouble().pow(2.2).toFloat()
+                        } else {
+                            zoom.toDouble().pow(1.1).toFloat()
+                        }
+
+                        val newScale = (scale * adjustedZoom).coerceIn(1f, 8f)
+
+                        val maxOffsetX = ((screenWidth * newScale) - screenWidth) / 2f
+                        val maxOffsetY = ((screenHeight * newScale) - screenHeight) / 2f
+
+                        // Je stärker hineingezoomt ist, desto schneller soll die Karte verschiebbar sein.
+                        val panSpeed = (newScale * 1.4f).coerceIn(2.5f, 10f)
+
+                        scale = newScale
+
+                        offset = if (newScale > 1f) {
+                            Offset(
+                                x = (offset.x + pan.x * panSpeed)
+                                    .coerceIn(-maxOffsetX, maxOffsetX),
+                                y = (offset.y + pan.y * panSpeed)
+                                    .coerceIn(-maxOffsetY, maxOffsetY)
+                            )
+                        } else {
+                            Offset.Zero
+                        }
                     }
                 }
-            }
-    )
+        )
+    }
 }
 
 //Hilfe damit App nicht abstürzt (bsp. derzeit noch fehlende Bilder)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
@@ -179,7 +179,7 @@ fun ZoomableMap(mapBitmap: ImageBitmap) {
     Image(
         bitmap = mapBitmap,
         contentDescription = "Weltkarte",
-        contentScale = ContentScale.Crop,
+        contentScale = ContentScale.Fit,
         modifier = Modifier
             .fillMaxSize()
             .graphicsLayer(

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
@@ -28,6 +28,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import at.aau.serg.websocketbrokerdemo.AppViewModel
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 
 @Composable
 fun GameScreen(viewModel: AppViewModel) {
@@ -61,12 +65,7 @@ fun GameScreen(viewModel: AppViewModel) {
 
         // Weltkarte
         if (mapBitmap != null) {
-            Image(
-                bitmap = mapBitmap,
-                contentDescription = "Weltkarte",
-                modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
-            )
+            ZoomableMap(mapBitmap = mapBitmap)
         }
 
         // Game Mode Badge oben rechts
@@ -171,8 +170,39 @@ fun GameScreen(viewModel: AppViewModel) {
 }
 
 
-//Hilfe damit App nicht abstürzt (bsp. derzeit noch fehlende Bilder)
+//Weltkarte mit Zoom und Verschiebe Funktion
+@Composable
+fun ZoomableMap(mapBitmap: ImageBitmap) {
+    var scale by remember {mutableStateOf(1f)}
+    var offset by remember {mutableStateOf(Offset.Zero)}
 
+    Image(
+        bitmap = mapBitmap,
+        contentDescription = "Weltkarte",
+        contentScale = ContentScale.Crop,
+        modifier = Modifier
+            .fillMaxSize()
+            .graphicsLayer(
+                scaleX = scale,
+                scaleY = scale,
+                translationX = offset.x,
+                translationY = offset.y
+            )
+            .pointerInput(Unit) {
+                detectTransformGestures { _, pan, zoom, _ ->
+                    scale = (scale * zoom).coerceIn(1f, 4f)
+
+                    if(scale > 1f) {
+                        offset += pan
+                    }else {
+                        offset = Offset.Zero
+                    }
+                }
+            }
+    )
+}
+
+//Hilfe damit App nicht abstürzt (bsp. derzeit noch fehlende Bilder)
 @Composable
 fun PlayerCard(name: String, bucketListCount: Int, avatar: ImageBitmap?, isActive: Boolean) {
     Row(


### PR DESCRIPTION
Ich habe im GameScreen die Weltkarte so erweitert, dass man jetzt hineinzoomen und die Karte verschieben kann.

Änderungen:
    Zoom (Pinch-to-Zoom) für die Karte implementiert
    Verschieben der Karte bei Zoom hinzugefügt
    Darstellung angepasst, sodass die komplette Weltkarte sichtbar ist und nichts mehr abgeschnitten wird

Getestet:
    App startet
    GameScreen wird angezeigt
    Karte lässt sich zoomen und verschieben

Closes #38 