### PR TITLE
Join-Back-Button und Spielmodus-Sync

### DIFF
--- a/app/src/main/java/MyStomp.kt
+++ b/app/src/main/java/MyStomp.kt
@@ -165,6 +165,21 @@ class MyStomp(val callbacks: Callbacks) {
         }
     }
 
+    fun updateGameMode(lobbyId: String, gameMode: String){
+        scope.launch {
+            try{
+                val command = JSONObject()
+                command.put("type", "UPDATE_GAME_MODE")
+                command.put("gameMode", gameMode)
+
+                session?.sendText("/app/lobby/$lobbyId/command", command.toString())
+                Log.i("Lobby", "Game mode update sent: $gameMode")
+            } catch (e: Exception){
+                Log.e("MyStomp", "Fehler beim Aktualisieren des Spielmodus", e)
+            }
+        }
+    }
+
     fun leaveLobby(lobbyId: String, playerId: String) {
         scope.launch {
             try {

--- a/app/src/main/java/MyStomp.kt
+++ b/app/src/main/java/MyStomp.kt
@@ -165,15 +165,16 @@ class MyStomp(val callbacks: Callbacks) {
         }
     }
 
-    fun updateGameMode(lobbyId: String, gameMode: String){
+    fun updateGameMode(lobbyId: String, playerId: String, gameMode: String){
         scope.launch {
             try{
                 val command = JSONObject()
                 command.put("type", "UPDATE_GAME_MODE")
+                command.put("playerId", playerId)
                 command.put("gameMode", gameMode)
 
                 session?.sendText("/app/lobby/$lobbyId/command", command.toString())
-                Log.i("Lobby", "Game mode update sent: $gameMode")
+                Log.i("Lobby", "Game mode update sent: $gameMode by player: $playerId")
             } catch (e: Exception){
                 Log.e("MyStomp", "Fehler beim Aktualisieren des Spielmodus", e)
             }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -110,7 +110,7 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
         _gameMode.value = mode
 
         if(_isHost.value && _lobbyId.value.isNotBlank()){
-            stomp.updateGameMode(_lobbyId.value, mode)
+            stomp.updateGameMode(_lobbyId.value, _playerName.value, mode)
         }
     }
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -108,6 +108,10 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
 
     fun setGameMode(mode: String) {
         _gameMode.value = mode
+
+        if(_isHost.value && _lobbyId.value.isNotBlank()){
+            stomp.updateGameMode(_lobbyId.value, mode)
+        }
     }
 
     init {
@@ -207,6 +211,10 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
                 // Erfolgreiche Response
                 if (rootJson.has("state") && !rootJson.isNull("state")) {
                     val stateJson = rootJson.getJSONObject("state")
+
+                    if(stateJson.has("gameMode") && !stateJson.isNull("gameMode")){
+                        _gameMode.value = stateJson.getString("gameMode")
+                    }
 
                     // Spielerliste und Städte aktualisieren
                     if (stateJson.has("players")) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
@@ -50,7 +50,10 @@ class MainActivity : ComponentActivity() {
                         HostScreen(viewModel)
                     }
                     "lobby" -> {
-                        LobbyScreen(viewModel)
+                        LobbyScreen(
+                            viewModel = viewModel,
+                            onBackClick = { viewModel.navigateTo("login") }
+                        )
                     }
                     "waiting" -> {
                         WaitingScreen(viewModel)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/HostScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/HostScreen.kt
@@ -113,18 +113,18 @@ fun HostScreen(viewModel: AppViewModel) {
                     Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                         TourButton(
                             text = "City Hopper\n(6)",
-                            isSelected = selectedTour == "City Hopper",
-                            onClick = { viewModel.setGameMode("City Hopper") }
+                            isSelected = selectedTour == "CITY_HOPPER",
+                            onClick = { viewModel.setGameMode("CITY_HOPPER") }
                         )
                         TourButton(
                             text = "Grand Tour\n(9)",
-                            isSelected = selectedTour == "Grand Tour",
-                            onClick = { viewModel.setGameMode("Grand Tour") }
+                            isSelected = selectedTour == "GRAND_TOUR",
+                            onClick = { viewModel.setGameMode("GRAND_TOUR") }
                         )
                         TourButton(
                             text = "Epic Voyage\n(12)",
-                            isSelected = selectedTour == "Epic Voyage",
-                            onClick = { viewModel.setGameMode("Epic Voyage") }
+                            isSelected = selectedTour == "EPIC_VOYAGE",
+                            onClick = { viewModel.setGameMode("EPIC_VOYAGE") }
                         )
                     }
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/LobbyScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/LobbyScreen.kt
@@ -1,6 +1,5 @@
 package at.aau.serg.websocketbrokerdemo.ui.theme
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,18 +9,22 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.stringResource
+import com.example.myapplication.R
+import androidx.compose.foundation.Image
+import androidx.compose.ui.res.painterResource
 
 import at.aau.serg.websocketbrokerdemo.AppViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun LobbyScreen(viewModel: AppViewModel) {
+fun LobbyScreen(
+    viewModel: AppViewModel,
+    onBackClick: () -> Unit
+) {
     var gamePin by remember { mutableStateOf("") }
     val errorMessage by viewModel.errorMessage.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
@@ -44,6 +47,25 @@ fun LobbyScreen(viewModel: AppViewModel) {
                 )
             )
     ) {
+        //Back Button oben links
+        Button(
+            onClick = onBackClick,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(16.dp)
+                .size(52.dp),
+            shape = RoundedCornerShape(50.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color(0xFFB71C1C)
+            ),
+            contentPadding = PaddingValues(0.dp)
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_arrow),
+                contentDescription = stringResource(R.string.back_button_description),
+                modifier = Modifier.size(28.dp)
+            )
+        }
         // Bildschirm teilen
         Row(
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/res/drawable/ic_arrow.xml
+++ b/app/src/main/res/drawable/ic_arrow.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.42,-1.41L7.83,13H20v-2z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,6 @@
 
     <string name="rule_end_title">🏁 End of the Game</string>
     <string name="rule_end_content">After completing all destinations, return to your starting city. The first player to do so wins.</string>
+
+    <string name="back_button_description">Back to start screen</string>
 </resources>


### PR DESCRIPTION
Dieser Pull Request enthält App-Anpassungen für Issue #64 und Issue #65.

Änderungen für Issue #64:
- Back-Button im Join-Screen ergänzt
- Spieler können vom Join-Screen zurück zum Login-/Start-Screen wechseln
- Darstellung im Emulator geprüft

Änderungen für Issue #65:
- UPDATE_GAME_MODE sendet nun die playerId mit
- Lobby-Buttons verwenden intern die serverkompatiblen Werte CITY_HOPPER, GRAND_TOUR und EPIC_VOYAGE
- AppViewModel übergibt den aktuellen Spieler beim Aktualisieren des Spielmodus
- HostScreen zeigt weiterhin lesbare Namen an, sendet intern aber die Serverwerte
- Spielmodus-Auswahl wird korrekt vom Server bestätigt

Getestet:
- Back-Button im Emulator geprüft
- Lobby als Host erstellt
- City Hopper, Grand Tour und Epic Voyage in der UI ausgewählt
- Logcat geprüft
- Server-Antwort mit commandType UPDATE_GAME_MODE erhalten
- Server-State aktualisiert sich korrekt, z. B. auf EPIC_VOYAGE

Closes #64
Related to #65