### PR TITLE
Feature/goal reached logic

### DIFF
--- a/app/src/main/java/MyStomp.kt
+++ b/app/src/main/java/MyStomp.kt
@@ -252,13 +252,12 @@ class MyStomp(val callbacks: Callbacks) {
         }
     }
 
-    fun endTurn(lobbyId: String, playerId: String, diceValue: Int) {
+    fun endTurn(lobbyId: String, playerId: String) {
         scope.launch {
             try {
                 val command = JSONObject()
-                command.put("type", "MOVE_TOKEN")
+                command.put("type", "END_TURN")
                 command.put("playerId", playerId)
-                command.put("moveSteps", diceValue)
                 session?.sendText("/app/lobby/$lobbyId/command", command.toString())
             } catch (e: Exception) {
                 Log.e("MyStomp", "Fehler beim Zug beenden", e)

--- a/app/src/main/java/MyStomp.kt
+++ b/app/src/main/java/MyStomp.kt
@@ -52,6 +52,25 @@ class MyStomp(val callbacks: Callbacks) {
                         callback(o.get("text").toString())
                     }
                 }
+
+                val goalReachedFlow = activeSession.subscribeText("/topic/goal-reached")
+                scope.launch {
+                    goalReachedFlow.collect { msg ->
+                        Log.d("MyStomp", "GOAL-REACHED received: $msg")
+                        callbackGoalReached(msg)
+                    }
+                }
+                Log.d("MyStomp", "Subscribed to /topic/goal-reached")
+
+                val gameOverFlow = activeSession.subscribeText("/topic/game-over")
+                scope.launch {
+                    gameOverFlow.collect { msg ->
+                        Log.d("MyStomp", "GAME-OVER received: $msg")
+                        callbackGameOver(msg)
+                    }
+                }
+                Log.d("MyStomp", "Subscribed to /topic/game-over")
+
                 callback("connected")
 
             } catch (e: Exception) {
@@ -64,6 +83,18 @@ class MyStomp(val callbacks: Callbacks) {
     private fun callback(msg: String) {
         Handler(Looper.getMainLooper()).post {
             callbacks.onResponse(msg)
+        }
+    }
+
+    private fun callbackGoalReached(msg: String) {
+        Handler(Looper.getMainLooper()).post {
+            callbacks.onGoalReached(msg)
+        }
+    }
+
+    private fun callbackGameOver(msg: String) {
+        Handler(Looper.getMainLooper()).post {
+            callbacks.onGameOver(msg)
         }
     }
 

--- a/app/src/main/java/MyStomp.kt
+++ b/app/src/main/java/MyStomp.kt
@@ -212,6 +212,20 @@ class MyStomp(val callbacks: Callbacks) {
         }
     }
 
+    fun resetLobby(lobbyId: String, playerId: String) {
+        scope.launch {
+            try {
+                val command = JSONObject()
+                command.put("type", "RESET_LOBBY")
+                command.put("playerId", playerId)
+                session?.sendText("/app/lobby/$lobbyId/command", command.toString())
+                Log.i("MyStomp", "RESET_LOBBY sent for lobby: $lobbyId by: $playerId")
+            } catch (e: Exception) {
+                Log.e("MyStomp", "Fehler beim Reset der Lobby", e)
+            }
+        }
+    }
+
     fun leaveLobby(lobbyId: String, playerId: String) {
         scope.launch {
             try {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -181,6 +181,7 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
     }
 
     fun onEndTurn() {
+        if (_diceValue.value == null) return
         _validMoveIds.value = emptyList()
         _remainingSteps.value = null
         stomp.endTurn(_lobbyId.value, _playerName.value)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -192,6 +192,21 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
         stomp.moveToCity(_lobbyId.value, _playerName.value, targetCityId)
     }
 
+    fun playAgain() {
+        _isGameOver.value = false
+        _gameOverMessage.value = null
+        _goalReachedMessage.value = null
+        _ownedCities.value = emptyList()
+        _startCity.value = null
+        _playerCityCounts.value = emptyMap()
+        _playerCurrentCities.value = emptyMap()
+        _diceValue.value = null
+        _currentTurnPlayerId.value = null
+        _validMoveIds.value = emptyList()
+        _remainingSteps.value = null
+        stomp.resetLobby(_lobbyId.value, _playerName.value)
+    }
+
     fun leaveLobby() {
         val currentLobbyId = _lobbyId.value
         val currentPlayerName = _playerName.value
@@ -346,6 +361,10 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
                             _playersList.value = emptyList()
                             _isHost.value = false
                             navigateTo("login")
+                        }
+                        commandType == "RESET_LOBBY" -> {
+                            if (_isHost.value) navigateTo("host")
+                            else navigateTo("waiting")
                         }
                         phase != "LOBBY" -> {
                             navigateTo("game")

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -339,12 +339,16 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
 
                     // Würfelergebnis und aktueller Spieler (dein bestehender Code)
                     _diceValue.value = if (stateJson.isNull("lastDiceValue")) null else stateJson.optInt("lastDiceValue")
-                    _currentTurnPlayerId.value = stateJson.optString("currentPlayerId").ifEmpty { null }
+                    val newCurrentPlayerId = stateJson.optString("currentPlayerId").ifEmpty { null }
+                    val isTurnChange = newCurrentPlayerId != _currentTurnPlayerId.value
+                    _currentTurnPlayerId.value = newCurrentPlayerId
 
                     val validIds = mutableListOf<String>()
-                    val validArray = stateJson.optJSONArray("validMoveIds")
-                    if (validArray != null) {
-                        for (i in 0 until validArray.length()) validIds.add(validArray.getString(i))
+                    if (!isTurnChange && newCurrentPlayerId == _playerName.value) {
+                        val validArray = stateJson.optJSONArray("validMoveIds")
+                        if (validArray != null) {
+                            for (i in 0 until validArray.length()) validIds.add(validArray.getString(i))
+                        }
                     }
                     _validMoveIds.value = validIds
 
@@ -388,7 +392,7 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
 
     override fun onGoalReached(res: String) {
         try {
-            val json = org.json.JSONObject(res)
+            val json = JSONObject(res)
             _goalReachedMessage.value = GoalReachedMessage(
                 playerName = json.optString("playerName"),
                 cityName = json.optString("cityName"),
@@ -403,7 +407,7 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
     override fun onGameOver(res: String) {
         _isGameOver.value = true
         try {
-            val json = org.json.JSONObject(res)
+            val json = JSONObject(res)
             val array = json.getJSONArray("results")
             val results = mutableListOf<GameOverMessage.PlayerResult>()
             for (i in 0 until array.length()) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -205,6 +205,14 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
         _goalReachedMessage.value = null
         _gameOverMessage.value = null
         _playerStartCityNames.value = emptyMap()
+        _ownedCities.value = emptyList()
+        _startCity.value = null
+        _playerCityCounts.value = emptyMap()
+        _playerCurrentCities.value = emptyMap()
+        _diceValue.value = null
+        _currentTurnPlayerId.value = null
+        _validMoveIds.value = emptyList()
+        _remainingSteps.value = null
         navigateTo("login")
     }
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -181,10 +181,9 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
     }
 
     fun onEndTurn() {
-        val dice = _diceValue.value ?: return
         _validMoveIds.value = emptyList()
         _remainingSteps.value = null
-        stomp.endTurn(_lobbyId.value, _playerName.value, dice)
+        stomp.endTurn(_lobbyId.value, _playerName.value)
     }
 
     fun onMoveToCity(targetCityId: String) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -408,7 +408,7 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
         _isGameOver.value = true
         try {
             val json = JSONObject(res)
-            val array = json.getJSONArray("results")
+            val array = json.getJSONArray("scores")
             val results = mutableListOf<GameOverMessage.PlayerResult>()
             for (i in 0 until array.length()) {
                 val item = array.getJSONObject(i)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -387,6 +387,7 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
                 ))
             }
             _gameOverMessage.value = GameOverMessage(results)
+            navigateTo("gameover")
         } catch (e: Exception) {
             Log.e("AppViewModel", "Failed to parse game-over", e)
         }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -6,6 +6,8 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import at.aau.serg.websocketbrokerdemo.models.City
 import at.aau.serg.websocketbrokerdemo.models.Continent
+import at.aau.serg.websocketbrokerdemo.models.GameOverMessage
+import at.aau.serg.websocketbrokerdemo.models.GoalReachedMessage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -65,6 +67,18 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
 
     private val _remainingSteps = MutableStateFlow<Int?>(null)
     val remainingSteps: StateFlow<Int?> = _remainingSteps.asStateFlow()
+
+    private val _playerStartCityNames = MutableStateFlow<Map<String, String>>(emptyMap())
+    val playerStartCityNames: StateFlow<Map<String, String>> = _playerStartCityNames.asStateFlow()
+
+    private val _goalReachedMessage = MutableStateFlow<GoalReachedMessage?>(null)
+    val goalReachedMessage: StateFlow<GoalReachedMessage?> = _goalReachedMessage.asStateFlow()
+
+    private val _gameOverMessage = MutableStateFlow<GameOverMessage?>(null)
+    val gameOverMessage: StateFlow<GameOverMessage?> = _gameOverMessage.asStateFlow()
+
+    private val _isGameOver = MutableStateFlow(false)
+    val isGameOver: StateFlow<Boolean> = _isGameOver.asStateFlow()
 
     fun loadAllCities(context: Context) {
         try {
@@ -187,6 +201,10 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
         _lobbyId.value = ""
         _playersList.value = emptyList()
         _isHost.value = false
+        _isGameOver.value = false
+        _goalReachedMessage.value = null
+        _gameOverMessage.value = null
+        _playerStartCityNames.value = emptyMap()
         navigateTo("login")
     }
 
@@ -222,6 +240,7 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
                         val newList = mutableListOf<String>()
                         val cityCountsMap = mutableMapOf<String, Int>()
                         val currentCitiesMap = mutableMapOf<String, City?>()
+                        val startCityNamesMap = _playerStartCityNames.value.toMutableMap()
 
                         for (i in 0 until playersArray.length()) {
                             val playerObj = playersArray.getJSONObject(i)
@@ -241,6 +260,12 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
                                 )
                             } else {
                                 currentCitiesMap[pId] = null
+                            }
+
+                            // Startstadt für alle Spieler merken (wird für "letzte Stadt"-Meldung gebraucht)
+                            if (playerObj.has("startCity") && !playerObj.isNull("startCity")) {
+                                val scName = playerObj.getJSONObject("startCity").optString("name", "")
+                                if (scName.isNotBlank()) startCityNamesMap[pId] = scName
                             }
 
                             if (playerObj.has("ownedCities")) {
@@ -283,6 +308,7 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
                                 }
                             }
                         }
+                        _playerStartCityNames.value = startCityNamesMap
                         _playersList.value = newList
                         _playerCityCounts.value = cityCountsMap
                         _playerCurrentCities.value = currentCitiesMap
@@ -330,6 +356,39 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
         } catch (e: Exception) {
             Log.e("AppViewModel", "Failed to parse JSON", e)
             _errorMessage.value = "Fehler bei Server-Kommunikation"
+        }
+    }
+
+    override fun onGoalReached(res: String) {
+        try {
+            val json = org.json.JSONObject(res)
+            _goalReachedMessage.value = GoalReachedMessage(
+                playerName = json.optString("playerName"),
+                cityName = json.optString("cityName"),
+                reached = json.optInt("reached"),
+                total = json.optInt("total")
+            )
+        } catch (e: Exception) {
+            Log.e("AppViewModel", "Failed to parse goal-reached", e)
+        }
+    }
+
+    override fun onGameOver(res: String) {
+        _isGameOver.value = true
+        try {
+            val json = org.json.JSONObject(res)
+            val array = json.getJSONArray("results")
+            val results = mutableListOf<GameOverMessage.PlayerResult>()
+            for (i in 0 until array.length()) {
+                val item = array.getJSONObject(i)
+                results.add(GameOverMessage.PlayerResult(
+                    playerName = item.optString("playerName"),
+                    score = item.optInt("score")
+                ))
+            }
+            _gameOverMessage.value = GameOverMessage(results)
+        } catch (e: Exception) {
+            Log.e("AppViewModel", "Failed to parse game-over", e)
         }
     }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -370,7 +370,7 @@ open class AppViewModel(stompInstance: MyStomp? = null) : ViewModel(), Callbacks
                             if (_isHost.value) navigateTo("host")
                             else navigateTo("waiting")
                         }
-                        phase != "LOBBY" -> {
+                        phase != "LOBBY" && !_isGameOver.value -> {
                             navigateTo("game")
                         }
                         commandType == "CREATE_LOBBY" -> {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/Callbacks.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/Callbacks.kt
@@ -1,5 +1,7 @@
 package at.aau.serg.websocketbrokerdemo
 
 interface Callbacks {
-    fun onResponse(res: String);
+    fun onResponse(res: String)
+    fun onGoalReached(res: String)
+    fun onGameOver(res: String)
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.viewModels
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import at.aau.serg.websocketbrokerdemo.ui.theme.GameOverScreen
 import at.aau.serg.websocketbrokerdemo.ui.theme.GameScreen
 import at.aau.serg.websocketbrokerdemo.ui.theme.HostScreen
 import at.aau.serg.websocketbrokerdemo.ui.theme.LobbyScreen
@@ -22,7 +23,7 @@ class MainActivity : ComponentActivity() {
         super.onStop()
         if (!isChangingConfigurations) {
             val screen = viewModel.currentScreen.value
-            if (screen == "host" || screen == "waiting") {
+            if (screen == "host" || screen == "waiting" || screen == "gameover") {
                 viewModel.leaveLobby()
             }
         }
@@ -60,6 +61,16 @@ class MainActivity : ComponentActivity() {
                     }
                     "game" -> {
                         GameScreen(viewModel)
+                    }
+                    "gameover" -> {
+                        val gameOverMessage by viewModel.gameOverMessage.collectAsState()
+                        val playerName by viewModel.playerName.collectAsState()
+                        GameOverScreen(
+                            currentPlayerName = playerName,
+                            results = gameOverMessage?.results ?: emptyList(),
+                            onPlayAgainClick = { /* Schritt 4 */ },
+                            onLeaveClick = { viewModel.leaveLobby() }
+                        )
                     }
                 }
             }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
@@ -68,7 +68,7 @@ class MainActivity : ComponentActivity() {
                         GameOverScreen(
                             currentPlayerName = playerName,
                             results = gameOverMessage?.results ?: emptyList(),
-                            onPlayAgainClick = { /* Schritt 4 */ },
+                            onPlayAgainClick = { viewModel.playAgain() },
                             onLeaveClick = { viewModel.leaveLobby() }
                         )
                     }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/models/GameOverMessage.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/models/GameOverMessage.kt
@@ -1,0 +1,10 @@
+package at.aau.serg.websocketbrokerdemo.models
+
+data class GameOverMessage(
+    val results: List<PlayerResult>
+) {
+    data class PlayerResult(
+        val playerName: String,
+        val score: Int
+    )
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/models/GoalReachedMessage.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/models/GoalReachedMessage.kt
@@ -1,0 +1,8 @@
+package at.aau.serg.websocketbrokerdemo.models
+
+data class GoalReachedMessage(
+    val playerName: String,
+    val cityName: String,
+    val reached: Int,
+    val total: Int
+)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameOverScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameOverScreen.kt
@@ -1,0 +1,192 @@
+package at.aau.serg.websocketbrokerdemo.ui.theme
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import at.aau.serg.websocketbrokerdemo.models.GameOverMessage
+
+private val GradientBackground = Brush.linearGradient(
+    colors = listOf(Color(0xFF003058), Color(0xFFFDCB61))
+)
+private val Gold = Color(0xFFD4AF37)
+private val Blue = Color(0xFF1E56A0)
+private val LightBlue = Color(0xFF90B8D4)
+private val Red = Color(0xFFB71C1C)
+
+@Composable
+fun GameOverScreen(
+    currentPlayerName: String,
+    results: List<GameOverMessage.PlayerResult>,
+    onPlayAgainClick: () -> Unit = {},
+    onLeaveClick: () -> Unit = {}
+) {
+    val sortedResults = results.sortedByDescending { it.score }
+    val winner = sortedResults.firstOrNull()?.playerName
+    val hasWon = currentPlayerName == winner
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(GradientBackground),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier.width(520.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Title
+            Text(
+                text = if (hasWon) "YOU WIN!" else "YOU LOSE!",
+                style = MaterialTheme.typography.displayMedium,
+                fontWeight = FontWeight.Bold,
+                color = if (hasWon) Gold else Color.White,
+                textAlign = TextAlign.Center
+            )
+
+            if (!hasWon && winner != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "$winner has won the game.",
+                    fontSize = 18.sp,
+                    color = Color.White.copy(alpha = 0.85f),
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            Spacer(modifier = Modifier.height(36.dp))
+
+            // Scoreboard card
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.White.copy(alpha = 0.85f))
+            ) {
+                Column(modifier = Modifier.padding(24.dp)) {
+                    Text(
+                        text = "FINAL SCORES",
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Gold,
+                        letterSpacing = 2.sp
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+                    HorizontalDivider(color = Gold, thickness = 1.dp)
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    sortedResults.forEachIndexed { index, result ->
+                        val isFirst = index == 0
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "#${index + 1}",
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = if (isFirst) Gold else Color.Gray,
+                                modifier = Modifier.width(36.dp)
+                            )
+                            Text(
+                                text = result.playerName,
+                                fontSize = 15.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = Blue,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Text(
+                                text = "${result.score} cities",
+                                fontSize = 14.sp,
+                                color = if (isFirst) Gold else Color.Gray,
+                                fontWeight = if (isFirst) FontWeight.Bold else FontWeight.Normal
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(40.dp))
+
+            // Action buttons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Button(
+                    onClick = onPlayAgainClick,
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(52.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = LightBlue)
+                ) {
+                    Text(
+                        text = "PLAY AGAIN",
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 15.sp
+                    )
+                }
+
+                Button(
+                    onClick = onLeaveClick,
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(52.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = Red)
+                ) {
+                    Text(
+                        text = "LEAVE GAME",
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 15.sp
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 800, heightDp = 500)
+@Composable
+fun GameOverScreenPreview() {
+    MaterialTheme {
+        GameOverScreen(
+            currentPlayerName = "Marco Polo",
+            results = listOf(
+                GameOverMessage.PlayerResult("DoraTheExplorer", 8),
+                GameOverMessage.PlayerResult("Marco Polo", 5),
+                GameOverMessage.PlayerResult("Indiana Jones", 3)
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 800, heightDp = 500)
+@Composable
+fun GameOverScreenWinnerPreview() {
+    MaterialTheme {
+        GameOverScreen(
+            currentPlayerName = "DoraTheExplorer",
+            results = listOf(
+                GameOverMessage.PlayerResult("DoraTheExplorer", 8),
+                GameOverMessage.PlayerResult("Marco Polo", 5),
+                GameOverMessage.PlayerResult("Indiana Jones", 3)
+            )
+        )
+    }
+}

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
@@ -53,6 +53,8 @@ import androidx.core.graphics.scale
 import androidx.core.graphics.withSave
 import at.aau.serg.websocketbrokerdemo.AppViewModel
 import at.aau.serg.websocketbrokerdemo.models.City
+import at.aau.serg.websocketbrokerdemo.models.GameOverMessage
+import at.aau.serg.websocketbrokerdemo.models.GoalReachedMessage
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import kotlin.math.abs
@@ -80,9 +82,13 @@ fun GameScreen(viewModel: AppViewModel) {
     val playerCurrentCities by viewModel.playerCurrentCities.collectAsState()
     val validMoveIds by viewModel.validMoveIds.collectAsState()
     val remainingSteps by viewModel.remainingSteps.collectAsState()
+    val isGameOver by viewModel.isGameOver.collectAsState()
+    val goalReachedMessage by viewModel.goalReachedMessage.collectAsState()
+    val gameOverMessage by viewModel.gameOverMessage.collectAsState()
     val isMyTurn = currentTurnPlayerId == currentPlayerName
-    val canRoll = isMyTurn && diceValue == null
-    val canEndTurn = isMyTurn && diceValue != null
+    val effectiveIsMyTurn = isMyTurn && !isGameOver
+    val canRoll = effectiveIsMyTurn && diceValue == null
+    val canEndTurn = effectiveIsMyTurn && diceValue != null
 
 
 
@@ -131,6 +137,19 @@ fun GameScreen(viewModel: AppViewModel) {
         }
     }
 
+    // Goal-Reached fade-out nach 4 Sekunden
+    var showGoalReachedOverlay by remember { mutableStateOf(false) }
+    val goalReachedAlpha = remember { Animatable(0f) }
+    LaunchedEffect(goalReachedMessage) {
+        if (goalReachedMessage != null) {
+            showGoalReachedOverlay = true
+            goalReachedAlpha.snapTo(1f)
+            delay(3000)
+            goalReachedAlpha.animateTo(0f, animationSpec = tween(1000))
+            showGoalReachedOverlay = false
+        }
+    }
+
     // Box (Schichten-Design)
     Box(
         modifier = Modifier
@@ -149,7 +168,7 @@ fun GameScreen(viewModel: AppViewModel) {
                 playerCurrentCities = playerCurrentCities,
                 rawAvatars = rawAvatars,
                 validMoveIds = validMoveIds,
-                isMyTurn = isMyTurn,
+                isMyTurn = effectiveIsMyTurn,
                 myPlayerId = currentPlayerName,
                 onCityClick = { cityId -> viewModel.onMoveToCity(cityId) }
             )
@@ -228,6 +247,65 @@ fun GameScreen(viewModel: AppViewModel) {
                     .background(Color(0x88000000), RoundedCornerShape(8.dp))
                     .padding(horizontal = 16.dp, vertical = 6.dp)
             )
+        }
+
+        // Goal-Reached Popup – für alle sichtbar, verschwindet nach 4s
+        if (showGoalReachedOverlay && goalReachedMessage != null) {
+            val msg = goalReachedMessage!!
+            Box(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .alpha(goalReachedAlpha.value)
+                    .background(Color(0xCC000000), RoundedCornerShape(20.dp))
+                    .padding(horizontal = 32.dp, vertical = 20.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "${msg.playerName} hat ${msg.cityName} erreicht!",
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFFD4AF37)
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "(${msg.reached}/${msg.total})",
+                        fontSize = 16.sp,
+                        color = Color.White
+                    )
+                }
+            }
+        }
+
+        // Game-Over Popup – provisorisch, persistent, kein Schließen-Button
+        if (isGameOver) {
+            val winnerName = gameOverMessage?.results?.maxByOrNull { it.score }?.playerName
+            Box(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .zIndex(10f)
+                    .background(Color(0xCC000000), RoundedCornerShape(20.dp))
+                    .padding(horizontal = 40.dp, vertical = 28.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    if (winnerName != null) {
+                        Text(
+                            text = "$winnerName hat gewonnen!",
+                            fontSize = 24.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = Color(0xFFD4AF37)
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                    Text(
+                        text = "Spiel beendet!",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+                }
+            }
         }
 
         //Actionbuttons

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
@@ -53,8 +53,6 @@ import androidx.core.graphics.scale
 import androidx.core.graphics.withSave
 import at.aau.serg.websocketbrokerdemo.AppViewModel
 import at.aau.serg.websocketbrokerdemo.models.City
-import at.aau.serg.websocketbrokerdemo.models.GameOverMessage
-import at.aau.serg.websocketbrokerdemo.models.GoalReachedMessage
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import kotlin.math.abs
@@ -431,7 +429,7 @@ fun ZoomableMap(
     myPlayerId: String = "",
     onCityClick: (cityId: String) -> Unit = {}
 ) {
-    val showValidMoves = validMoveIds.isNotEmpty()
+    val showValidMoves = validMoveIds.isNotEmpty() && isMyTurn
     val validMoveIdSet = remember(validMoveIds) { validMoveIds.toHashSet() }
     val ownedCityIdSet = remember(ownedCities) { ownedCities.map { it.id }.toHashSet() }
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
@@ -318,6 +318,7 @@ fun GameScreen(viewModel: AppViewModel) {
                 text = "ROLL DICE",
                 imageBitmap = diceBitmap,
                 enabled = canRoll,
+                blinkBorder = canRoll,
                 onClick = { viewModel.onRollDice() }
             )
 
@@ -909,11 +910,25 @@ fun PlayerCard(name: String, bucketListCount: Int, avatar: ImageBitmap?, isActiv
 }
 
 @Composable
-fun GameButton(text: String, imageBitmap: ImageBitmap?, onClick: () -> Unit, enabled: Boolean = true) {
+fun GameButton(text: String, imageBitmap: ImageBitmap?, onClick: () -> Unit, enabled: Boolean = true, blinkBorder: Boolean = false) {
     val bgColor = if (enabled) Color.White.copy(alpha = 0.8f) else Color.Gray.copy(alpha = 0.4f)
+    val infiniteTransition = rememberInfiniteTransition(label = "rollDiceBorder")
+    val borderAlpha by infiniteTransition.animateFloat(
+        initialValue = 0.3f,
+        targetValue = 1.0f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(600, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "borderAlpha"
+    )
+    val borderModifier = if (blinkBorder)
+        Modifier.border(4.dp, Color(0xFFFFD700).copy(alpha = borderAlpha), RoundedCornerShape(16.dp))
+    else Modifier
     Box(
         modifier = Modifier
             .size(120.dp)
+            .then(borderModifier)
             .background(bgColor, RoundedCornerShape(16.dp))
             .then(if (enabled) Modifier.clickable { onClick() } else Modifier)
             .padding(12.dp),

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/AppViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/AppViewModelTest.kt
@@ -617,6 +617,191 @@ class AppViewModelTest {
         assertNull(viewModel.currentTurnPlayerId.value)
     }
 
+    // ========== PLAYER START CITY NAMES TESTS ==========
+
+    @Test
+    fun `onResponse parses startCity names for all players`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        val response = """{"success":true,"commandType":"START_GAME","state":{"players":[
+            {"playerId":"Alice","startCity":{"id":"1","name":"Berlin","continent":"EUROPE_AFRICA"},"ownedCities":[]},
+            {"playerId":"Bob","startCity":{"id":"2","name":"Madrid","continent":"EUROPE_AFRICA"},"ownedCities":[]}
+        ],"phase":"IN_TURN"}}"""
+        viewModel.onResponse(response)
+
+        assertEquals("Berlin", viewModel.playerStartCityNames.value["Alice"])
+        assertEquals("Madrid", viewModel.playerStartCityNames.value["Bob"])
+    }
+
+    @Test
+    fun `onResponse retains startCity name if later state omits it`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        val first = """{"success":true,"commandType":"START_GAME","state":{"players":[
+            {"playerId":"Alice","startCity":{"id":"1","name":"Berlin","continent":"EUROPE_AFRICA"},"ownedCities":[]}
+        ],"phase":"IN_TURN"}}"""
+        viewModel.onResponse(first)
+
+        val second = """{"success":true,"commandType":"ROLL_DICE","state":{"players":[
+            {"playerId":"Alice","ownedCities":[]}
+        ],"phase":"IN_TURN","currentPlayerId":"Alice","lastDiceValue":3}}"""
+        viewModel.onResponse(second)
+
+        assertEquals("Berlin", viewModel.playerStartCityNames.value["Alice"])
+    }
+
+    @Test
+    fun `leaveLobby clears playerStartCityNames`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        val response = """{"success":true,"commandType":"START_GAME","state":{"players":[
+            {"playerId":"Alice","startCity":{"id":"1","name":"Berlin","continent":"EUROPE_AFRICA"},"ownedCities":[]}
+        ],"phase":"IN_TURN"}}"""
+        viewModel.onResponse(response)
+
+        viewModel.leaveLobby()
+
+        assertTrue(viewModel.playerStartCityNames.value.isEmpty())
+    }
+
+    // ========== GOAL-REACHED TESTS ==========
+
+    @Test
+    fun `onGoalReached parses message and updates goalReachedMessage`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        viewModel.onGoalReached("""{"playerName":"Alice","cityName":"Paris","reached":3,"total":9}""")
+
+        val msg = viewModel.goalReachedMessage.value
+        assertNotNull(msg)
+        assertEquals("Alice", msg!!.playerName)
+        assertEquals("Paris", msg.cityName)
+        assertEquals(3, msg.reached)
+        assertEquals(9, msg.total)
+    }
+
+    @Test
+    fun `onGoalReached with invalid JSON does not update goalReachedMessage`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        viewModel.onGoalReached("{invalid json")
+
+        assertNull(viewModel.goalReachedMessage.value)
+    }
+
+    @Test
+    fun `onGoalReached second call overwrites previous message`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.onGoalReached("""{"playerName":"Alice","cityName":"Paris","reached":1,"total":9}""")
+
+        viewModel.onGoalReached("""{"playerName":"Bob","cityName":"Tokyo","reached":2,"total":9}""")
+
+        val msg = viewModel.goalReachedMessage.value
+        assertEquals("Bob", msg!!.playerName)
+        assertEquals("Tokyo", msg.cityName)
+    }
+
+    // ========== GAME-OVER TESTS ==========
+
+    @Test
+    fun `onGameOver sets isGameOver to true`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        viewModel.onGameOver("""{"results":[{"playerName":"Alice","score":5}]}""")
+
+        assertTrue(viewModel.isGameOver.value)
+    }
+
+    @Test
+    fun `onGameOver parses results correctly`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        viewModel.onGameOver("""{"results":[{"playerName":"Alice","score":5},{"playerName":"Bob","score":3}]}""")
+
+        val msg = viewModel.gameOverMessage.value
+        assertNotNull(msg)
+        assertEquals(2, msg!!.results.size)
+        assertEquals("Alice", msg.results[0].playerName)
+        assertEquals(5, msg.results[0].score)
+        assertEquals("Bob", msg.results[1].playerName)
+        assertEquals(3, msg.results[1].score)
+    }
+
+    @Test
+    fun `onGameOver with invalid JSON still sets isGameOver to true`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        viewModel.onGameOver("{invalid json")
+
+        assertTrue(viewModel.isGameOver.value)
+        assertNull(viewModel.gameOverMessage.value)
+    }
+
+    @Test
+    fun `isGameOver is false initially`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        assertFalse(viewModel.isGameOver.value)
+    }
+
+    @Test
+    fun `goalReachedMessage is null initially`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        assertNull(viewModel.goalReachedMessage.value)
+    }
+
+    @Test
+    fun `gameOverMessage is null initially`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+
+        assertNull(viewModel.gameOverMessage.value)
+    }
+
+    @Test
+    fun `leaveLobby resets isGameOver to false`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.onGameOver("""{"results":[{"playerName":"Alice","score":5}]}""")
+
+        viewModel.leaveLobby()
+
+        assertFalse(viewModel.isGameOver.value)
+    }
+
+    @Test
+    fun `leaveLobby resets goalReachedMessage to null`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.onGoalReached("""{"playerName":"Alice","cityName":"Paris","reached":1,"total":9}""")
+
+        viewModel.leaveLobby()
+
+        assertNull(viewModel.goalReachedMessage.value)
+    }
+
+    @Test
+    fun `leaveLobby resets gameOverMessage to null`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.onGameOver("""{"results":[{"playerName":"Alice","score":5}]}""")
+
+        viewModel.leaveLobby()
+
+        assertNull(viewModel.gameOverMessage.value)
+    }
+
     // ========== HELPER ==========
 
     private fun createViewModelWithMockStomp(mockStomp: MyStomp): AppViewModel {

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/AppViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/AppViewModelTest.kt
@@ -1,7 +1,6 @@
 package at.aau.serg.websocketbrokerdemo
 
 import MyStomp
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
@@ -549,7 +548,7 @@ class AppViewModelTest {
 
         viewModel.onEndTurn()
 
-        verify { mockStomp.endTurn(lobbyId, "Alice", 4) }
+        verify { mockStomp.endTurn(lobbyId, "Alice") }
     }
 
     @Test
@@ -559,7 +558,7 @@ class AppViewModelTest {
 
         viewModel.onEndTurn()
 
-        verify(exactly = 0) { mockStomp.endTurn(any(), any(), any()) }
+        verify(exactly = 0) { mockStomp.endTurn(any(), any()) }
     }
 
     @Test

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/AppViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/AppViewModelTest.kt
@@ -712,7 +712,7 @@ class AppViewModelTest {
         val mockStomp = mockk<MyStomp>(relaxed = true)
         val viewModel = createViewModelWithMockStomp(mockStomp)
 
-        viewModel.onGameOver("""{"results":[{"playerName":"Alice","score":5}]}""")
+        viewModel.onGameOver("""{"scores":[{"playerName":"Alice","score":5}]}""")
 
         assertTrue(viewModel.isGameOver.value)
     }
@@ -722,7 +722,7 @@ class AppViewModelTest {
         val mockStomp = mockk<MyStomp>(relaxed = true)
         val viewModel = createViewModelWithMockStomp(mockStomp)
 
-        viewModel.onGameOver("""{"results":[{"playerName":"Alice","score":5},{"playerName":"Bob","score":3}]}""")
+        viewModel.onGameOver("""{"scores":[{"playerName":"Alice","score":5},{"playerName":"Bob","score":3}]}""")
 
         val msg = viewModel.gameOverMessage.value
         assertNotNull(msg)
@@ -734,6 +734,17 @@ class AppViewModelTest {
     }
 
     @Test
+    fun `onGameOver navigates to gameover screen`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.navigateTo("game")
+
+        viewModel.onGameOver("""{"scores":[{"playerName":"Alice","score":5}]}""")
+
+        assertEquals("gameover", viewModel.currentScreen.value)
+    }
+
+    @Test
     fun `onGameOver with invalid JSON still sets isGameOver to true`() {
         val mockStomp = mockk<MyStomp>(relaxed = true)
         val viewModel = createViewModelWithMockStomp(mockStomp)
@@ -742,6 +753,17 @@ class AppViewModelTest {
 
         assertTrue(viewModel.isGameOver.value)
         assertNull(viewModel.gameOverMessage.value)
+    }
+
+    @Test
+    fun `onGameOver with invalid JSON does not navigate to gameover`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.navigateTo("game")
+
+        viewModel.onGameOver("{invalid json")
+
+        assertEquals("game", viewModel.currentScreen.value)
     }
 
     @Test
@@ -772,7 +794,7 @@ class AppViewModelTest {
     fun `leaveLobby resets isGameOver to false`() {
         val mockStomp = mockk<MyStomp>(relaxed = true)
         val viewModel = createViewModelWithMockStomp(mockStomp)
-        viewModel.onGameOver("""{"results":[{"playerName":"Alice","score":5}]}""")
+        viewModel.onGameOver("""{"scores":[{"playerName":"Alice","score":5}]}""")
 
         viewModel.leaveLobby()
 
@@ -794,11 +816,86 @@ class AppViewModelTest {
     fun `leaveLobby resets gameOverMessage to null`() {
         val mockStomp = mockk<MyStomp>(relaxed = true)
         val viewModel = createViewModelWithMockStomp(mockStomp)
-        viewModel.onGameOver("""{"results":[{"playerName":"Alice","score":5}]}""")
+        viewModel.onGameOver("""{"scores":[{"playerName":"Alice","score":5}]}""")
 
         viewModel.leaveLobby()
 
         assertNull(viewModel.gameOverMessage.value)
+    }
+
+    // ========== PLAY AGAIN TESTS ==========
+
+    @Test
+    fun `playAgain resets isGameOver to false`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.onGameOver("""{"scores":[{"playerName":"Alice","score":5}]}""")
+
+        viewModel.playAgain()
+
+        assertFalse(viewModel.isGameOver.value)
+    }
+
+    @Test
+    fun `playAgain resets gameOverMessage to null`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.onGameOver("""{"scores":[{"playerName":"Alice","score":5}]}""")
+
+        viewModel.playAgain()
+
+        assertNull(viewModel.gameOverMessage.value)
+    }
+
+    @Test
+    fun `playAgain resets goalReachedMessage to null`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.onGoalReached("""{"playerName":"Alice","cityName":"Paris","reached":1,"total":9}""")
+
+        viewModel.playAgain()
+
+        assertNull(viewModel.goalReachedMessage.value)
+    }
+
+    @Test
+    fun `playAgain calls stomp resetLobby`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.hostLobby("Alice")
+        val lobbyId = viewModel.lobbyId.value
+
+        viewModel.playAgain()
+
+        verify { mockStomp.resetLobby(lobbyId, "Alice") }
+    }
+
+    // ========== RESET LOBBY RESPONSE TESTS ==========
+
+    @Test
+    fun `onResponse with RESET_LOBBY navigates host to host screen`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.hostLobby("Alice")
+        viewModel.navigateTo("gameover")
+
+        val response = """{"success":true,"commandType":"RESET_LOBBY","state":{"players":[{"playerId":"Alice"},{"playerId":"Bob"}],"phase":"LOBBY"}}"""
+        viewModel.onResponse(response)
+
+        assertEquals("host", viewModel.currentScreen.value)
+    }
+
+    @Test
+    fun `onResponse with RESET_LOBBY navigates guest to waiting screen`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.joinLobby("1234")
+        viewModel.navigateTo("gameover")
+
+        val response = """{"success":true,"commandType":"RESET_LOBBY","state":{"players":[{"playerId":"Host"},{"playerId":"Guest"}],"phase":"LOBBY"}}"""
+        viewModel.onResponse(response)
+
+        assertEquals("waiting", viewModel.currentScreen.value)
     }
 
     // ========== HELPER ==========

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/AppViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/AppViewModelTest.kt
@@ -823,6 +823,18 @@ class AppViewModelTest {
         assertNull(viewModel.gameOverMessage.value)
     }
 
+    @Test
+    fun `onResponse does not navigate to game when game is already over`() {
+        val mockStomp = mockk<MyStomp>(relaxed = true)
+        val viewModel = createViewModelWithMockStomp(mockStomp)
+        viewModel.onGameOver("""{"scores":[{"playerName":"Alice","score":5}]}""")
+
+        val response = """{"success":true,"commandType":"MOVE_TO_CITY","state":{"players":[{"playerId":"Alice"}],"phase":"IN_TURN"}}"""
+        viewModel.onResponse(response)
+
+        assertEquals("gameover", viewModel.currentScreen.value)
+    }
+
     // ========== PLAY AGAIN TESTS ==========
 
     @Test


### PR DESCRIPTION
Implementierung der Ziel-erreicht- und Spielende-Anzeige in der Android-App.

  - GameOverScreen: Neuer Compose-Screen (GameOverScreen.kt), der nach Spielende automatisch angezeigt wird. Er zeigt
  „YOU WIN!" bzw. „YOU LOSE!" sowie eine sortierte Punkte-Rangliste aller Spieler. Über zwei Buttons kann der Spieler
  entweder direkt neu starten (Play Again) oder die Lobby verlassen (Leave Game).
  - WebSocket-Integration: MyStomp abonniert die neuen Topics /topic/goal-reached und /topic/game-over. Eingehende
  Nachrichten werden über onGoalReached() und onGameOver() im AppViewModel verarbeitet.
  - ViewModel-Logik: Neue StateFlows goalReachedMessage, gameOverMessage und isGameOver steuern die UI reaktiv. Bei
  Spielende navigiert das ViewModel automatisch zum GameOverScreen.
  - Play Again: playAgain() setzt den gesamten Spielzustand zurück und sendet den RESET_LOBBY-Befehl an den Server; Host
   und Gäste landen jeweils auf ihrem passenden Warte-Screen.
  - Lobby verlassen: leaveLobby() wurde erweitert, sodass auch Spiel-States (Städte, Würfelwert, Rundeninfos)
  vollständig geleert werden.
  - Bugfix: Blinkende Stadt-Animation wird nur noch für den aktiven Spieler angezeigt und endet korrekt, wenn der
  Spieler seinen Zug beendet. Außerdem ist previousCity jetzt in der Folgerunde korrekt verfügbar.
  - Tests: AppViewModelTest wurde um Tests für die Ziel- und Spielende-Callbacks erweitert. #68 #51 #40 