### PR TITLE
chore: ignore Android keystores and env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,12 @@ local.properties
 # OS files
 .DS_Store
 
+# Android Signing Keys (NIEMALS committen!)
+*.keystore
+*.jks
+key.properties
+keystore.properties
+
+# Environment files (Secrets)
+.env
+.env.*


### PR DESCRIPTION
 Erweitert `.gitignore` um sicherheitsrelevante Einträge:
  - Android Signing Keys (`*.keystore`, `*.jks`, `key.properties`, `keystore.properties`) — sollten niemals committet werden
  - Environment Files (`.env`, `.env.*`) — können Secrets enthalten