### PR TITLE
fix(game-over): non-host play-again + winner from server

### DIFF
--- a/app/src/main/java/MyStomp.kt
+++ b/app/src/main/java/MyStomp.kt
@@ -17,8 +17,8 @@ import org.hildan.krossbow.stomp.subscribeText
 import org.hildan.krossbow.websocket.okhttp.OkHttpWebSocketClient
 import org.json.JSONObject
 
-//private const val WEBSOCKET_URI = "ws://10.0.2.2:8080/websocket-example-broker"
-private const val WEBSOCKET_URI = "ws://se2-demo.aau.at:53205/websocket-example-broker"
+private const val WEBSOCKET_URI = "ws://10.0.2.2:8080/websocket-example-broker"
+//private const val WEBSOCKET_URI = "ws://se2-demo.aau.at:53205/websocket-example-broker"
 private const val RECONNECT_INITIAL_DELAY_MS = 2000L
 private const val RECONNECT_MAX_DELAY_MS = 30_000L
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -235,18 +235,28 @@ open class AppViewModel(
     }
 
     fun playAgain() {
-        _isGameOver.value = false
-        _gameOverMessage.value = null
-        _goalReachedMessage.value = null
-        _ownedCities.value = emptyList()
-        _startCity.value = null
-        _playerCityCounts.value = emptyMap()
-        _playerCurrentCities.value = emptyMap()
-        _diceValue.value = null
-        _currentTurnPlayerId.value = null
-        _validMoveIds.value = emptyList()
-        _remainingSteps.value = null
-        stomp.resetLobby(_lobbyId.value, _playerName.value)
+        if (_isHost.value) {
+            _isGameOver.value = false
+            _gameOverMessage.value = null
+            _goalReachedMessage.value = null
+            _ownedCities.value = emptyList()
+            _startCity.value = null
+            _playerCityCounts.value = emptyMap()
+            _playerCurrentCities.value = emptyMap()
+            _diceValue.value = null
+            _currentTurnPlayerId.value = null
+            _validMoveIds.value = emptyList()
+            _remainingSteps.value = null
+            stomp.resetLobby(_lobbyId.value, _playerName.value)
+        } else {
+            // Nicht-Host: nur GameOver-Anzeige schliessen und in den Waiting-Screen wechseln.
+            // Sobald der Host RESET_LOBBY ausloest, kommt ein frischer State per Broadcast.
+            // Falls der Host stattdessen die Lobby schliesst, navigiert LOBBY_CLOSED uns zum Login.
+            _isGameOver.value = false
+            _gameOverMessage.value = null
+            _goalReachedMessage.value = null
+            navigateTo("waiting")
+        }
     }
 
     fun leaveLobby() {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -572,6 +572,7 @@ open class AppViewModel(
         _isGameOver.value = true
         try {
             val json = JSONObject(res)
+            val winnerId = json.optString("winnerId")
             val array = json.getJSONArray("scores")
             val results = mutableListOf<GameOverMessage.PlayerResult>()
             for (i in 0 until array.length()) {
@@ -581,7 +582,7 @@ open class AppViewModel(
                     score = item.optInt("score")
                 ))
             }
-            _gameOverMessage.value = GameOverMessage(results)
+            _gameOverMessage.value = GameOverMessage(winnerId, results)
             navigateTo("gameover")
         } catch (e: Exception) {
             Log.e("AppViewModel", "Failed to parse game-over", e)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
@@ -91,6 +91,7 @@ class MainActivity : ComponentActivity() {
                             val playerName by viewModel.playerName.collectAsState()
                             GameOverScreen(
                                 currentPlayerName = playerName,
+                                winnerId = gameOverMessage?.winnerId,
                                 results = gameOverMessage?.results ?: emptyList(),
                                 onPlayAgainClick = { viewModel.playAgain() },
                                 onLeaveClick = { viewModel.leaveLobby() }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/models/GameOverMessage.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/models/GameOverMessage.kt
@@ -1,6 +1,7 @@
 package at.aau.serg.websocketbrokerdemo.models
 
 data class GameOverMessage(
+    val winnerId: String,
     val results: List<PlayerResult>
 ) {
     data class PlayerResult(

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameOverScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameOverScreen.kt
@@ -27,12 +27,18 @@ private val Red = Color(0xFFB71C1C)
 @Composable
 fun GameOverScreen(
     currentPlayerName: String,
+    winnerId: String?,
     results: List<GameOverMessage.PlayerResult>,
     onPlayAgainClick: () -> Unit = {},
     onLeaveClick: () -> Unit = {}
 ) {
-    val sortedResults = results.sortedByDescending { it.score }
-    val winner = sortedResults.firstOrNull()?.playerName
+    val winner = winnerId?.takeIf { it.isNotBlank() }
+        ?: results.maxByOrNull { it.score }?.playerName
+    // Echten Sieger immer auf Platz 1, restliche Spieler nach Score absteigend.
+    val sortedResults = results.sortedWith(
+        compareByDescending<GameOverMessage.PlayerResult> { it.playerName == winner }
+            .thenByDescending { it.score }
+    )
     val hasWon = currentPlayerName == winner
 
     Box(
@@ -167,6 +173,7 @@ fun GameOverScreenPreview() {
     MaterialTheme {
         GameOverScreen(
             currentPlayerName = "Marco Polo",
+            winnerId = "DoraTheExplorer",
             results = listOf(
                 GameOverMessage.PlayerResult("DoraTheExplorer", 8),
                 GameOverMessage.PlayerResult("Marco Polo", 5),
@@ -182,6 +189,7 @@ fun GameOverScreenWinnerPreview() {
     MaterialTheme {
         GameOverScreen(
             currentPlayerName = "DoraTheExplorer",
+            winnerId = "DoraTheExplorer",
             results = listOf(
                 GameOverMessage.PlayerResult("DoraTheExplorer", 8),
                 GameOverMessage.PlayerResult("Marco Polo", 5),


### PR DESCRIPTION
## Summary
  - Nicht-Host-Klick auf "Play Again" navigiert jetzt sauber in den Waiting-Screen, statt im kaputten Game-Over-Screen hängen zu bleiben.
  - Der Sieger im Scoreboard wird über das neue `winnerId`-Feld aus der `GameOverMessage` bestimmt (statt aus der Score-Sortierung). Der echte Sieger landet immer auf Platz #1 (Gold) — auch bei Score-Gleichstand.