### PR TITLE
fix(lobby): send playerId with START_GAME so the start button works a…

### DIFF
--- a/app/src/main/java/MyStomp.kt
+++ b/app/src/main/java/MyStomp.kt
@@ -305,11 +305,12 @@ class MyStomp(val callbacks: Callbacks) {
         }
     }
 
-    fun startGameCmd(lobbyId: String, stops: Int) {
+    fun startGameCmd(lobbyId: String, playerId: String, stops: Int) {
         scope.launch {
             try {
                 val command = JSONObject()
                 command.put("type", "START_GAME")
+                command.put("playerId", playerId)
                 command.put("stops", stops)
                 session?.sendText("/app/lobby/$lobbyId/command", command.toString())
             } catch (e: Exception) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/AppViewModel.kt
@@ -275,7 +275,7 @@ open class AppViewModel(
             "Epic Voyage" -> 12
             else -> 9
         }
-        stomp.startGameCmd(_lobbyId.value, stops)
+        stomp.startGameCmd(_lobbyId.value, _playerName.value, stops)
     }
 
     fun onRollDice() {

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/AppViewModelTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/AppViewModelTest.kt
@@ -322,7 +322,8 @@ class AppViewModelTest {
 
         viewModel.startGame()
 
-        verify { mockStomp.startGameCmd(lobbyId, any()) }
+        // playerId must be sent so the server's session authorization accepts START_GAME.
+        verify { mockStomp.startGameCmd(lobbyId, "Host", any()) }
     }
 
     // ========== PLAYER LIST TESTS ==========


### PR DESCRIPTION
  ###  Bugfix: Start-Journey-Button
  - `START_GAME` sendet jetzt die `playerId` mit (war das einzige Command ohne)
    → vom neuen Session-Auth-Check des Servers nicht mehr abgelehnt.