### PR TITLE
fix: Minispiel-Result-Screens scrollbar + restliche UI-Texte auf Englisch

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/GameScreen.kt
@@ -649,7 +649,7 @@ fun GameScreen(viewModel: AppViewModel) {
             ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(
-                        text = "${msg.playerName} hat ${msg.cityName} erreicht!",
+                        text = "${msg.playerName} reached ${msg.cityName}!",
                         fontSize = 20.sp,
                         fontWeight = FontWeight.Bold,
                         color = Color(0xFFD4AF37)
@@ -677,14 +677,14 @@ fun GameScreen(viewModel: AppViewModel) {
             ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(
-                        text = "$allReachedPlayerName hat alle Ziele erreicht!",
+                        text = "$allReachedPlayerName reached all destinations!",
                         fontSize = 18.sp,
                         fontWeight = FontWeight.Bold,
                         color = Color(0xFFD4AF37)
                     )
                     Spacer(modifier = Modifier.height(6.dp))
                     Text(
-                        text = "Weiter zur Startstadt: $allReachedStartCityName",
+                        text = "On to the starting city: $allReachedStartCityName",
                         fontSize = 15.sp,
                         color = Color.White
                     )
@@ -886,7 +886,7 @@ fun GameScreen(viewModel: AppViewModel) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     if (winnerName != null) {
                         Text(
-                            text = "$winnerName hat gewonnen!",
+                            text = "$winnerName has won!",
                             fontSize = 24.sp,
                             fontWeight = FontWeight.Bold,
                             color = Color(0xFFD4AF37)
@@ -894,7 +894,7 @@ fun GameScreen(viewModel: AppViewModel) {
                         Spacer(modifier = Modifier.height(8.dp))
                     }
                     Text(
-                        text = "Spiel beendet!",
+                        text = "Game over!",
                         fontSize = 18.sp,
                         fontWeight = FontWeight.Bold,
                         color = Color.White
@@ -970,7 +970,7 @@ fun GameScreen(viewModel: AppViewModel) {
                 ) {
                     if (startCity != null) {
                         Text(
-                            text = "🏠 Startstadt",
+                            text = "🏠 Start city",
                             fontWeight = FontWeight.Bold,
                             fontSize = 13.sp,
                             color = Color(0xFF1E56A0)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/MinigameOverlay.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/MinigameOverlay.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -964,13 +965,22 @@ private fun MinigameResultScreen(
         displayedAnswer = target
     }
 
+    // Cap height to the available window so the Continue button stays reachable
+    // (with 3-4 players the ranked rows would otherwise push it off-screen).
+    val screenHeight = with(LocalDensity.current) {
+        LocalWindowInfo.current.containerSize.height.toDp()
+    }
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.widthIn(max = 320.dp)
+        modifier = Modifier
+            .widthIn(max = 320.dp)
+            .heightIn(max = screenHeight - 80.dp)
+            .verticalScroll(rememberScrollState())
     ) {
         // "THE ANSWER" label
         Text(
-            text = "DIE ANTWORT",
+            text = "THE ANSWER",
             color = GuessWhite40,
             fontSize = 10.sp,
             fontWeight = FontWeight.ExtraBold,
@@ -1002,7 +1012,7 @@ private fun MinigameResultScreen(
         // Ranked player rows
         if (sortedEntries.isEmpty()) {
             Text(
-                text = "Keine Einsendungen",
+                text = "No submissions",
                 color = GuessWhite65,
                 fontSize = 15.sp
             )
@@ -1094,7 +1104,16 @@ private fun MinigameFlagResultScreen(
             .thenBy { flagTotalTimeMs[it] ?: Long.MAX_VALUE }
     )
 
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    val screenHeight = with(LocalDensity.current) {
+        LocalWindowInfo.current.containerSize.height.toDp()
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .heightIn(max = screenHeight - 80.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
         Text(
             text = winnerPlayerId?.let { "🏆 $it wins!" } ?: "Result",
             color = Color(0xFFD4AF37),

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/MinigameOverlay.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/MinigameOverlay.kt
@@ -340,7 +340,7 @@ fun MinigameOverlay(
 
                 else -> {
                     Text(
-                        text = "Minispiel wird geladen...",
+                        text = "Loading mini-game...",
                         color = Color.White,
                         fontSize = 18.sp,
                         fontWeight = FontWeight.Bold
@@ -420,10 +420,10 @@ private fun ReactionResultInfoScreen(
 }
 
 private val KNOWN_MINIGAMES = listOf(
-    "GUESS_GAME" to "Schätzspiel",
-    "QUIZ_GAME" to "Quizspiel",
+    "GUESS_GAME" to "Guessing Game",
+    "QUIZ_GAME" to "Quiz Game",
     "FLAG_GAME" to "Guess the Flag",
-    "REACTION_GAME" to "Reaktionsspiel",
+    "REACTION_GAME" to "Reaction Game",
 )
 
 @Composable
@@ -457,7 +457,7 @@ private fun MinigameSelectingScreen(selectedMinigame: String?) {
         modifier = Modifier.widthIn(min = 280.dp)
     ) {
         Text(
-            text = if (revealed) "Minispiel ausgewählt!" else "Minispiel wird ausgewählt...",
+            text = if (revealed) "Mini-game selected!" else "Selecting mini-game...",
             color = Color.White,
             fontSize = 18.sp,
             fontWeight = FontWeight.Bold,
@@ -925,7 +925,7 @@ private fun MinigamePlayingScreen(
                     .height(50.dp)
             ) {
                 Text(
-                    text = "Absenden",
+                    text = "Submit",
                     color = Color(0xFF0C1622),
                     fontSize = 16.sp,
                     fontWeight = FontWeight.ExtraBold
@@ -1067,7 +1067,7 @@ private fun MinigameResultScreen(
                     .height(52.dp)
             ) {
                 Text(
-                    text = "Weiter",
+                    text = "Continue",
                     color = Color(0xFF0C1622),
                     fontSize = 16.sp,
                     fontWeight = FontWeight.ExtraBold
@@ -1151,7 +1151,7 @@ private fun MinigameFlagResultScreen(
                     .height(56.dp)
             ) {
                 Text(
-                    text = "Weiter",
+                    text = "Continue",
                     color = Color.White,
                     fontSize = 17.sp,
                     fontWeight = FontWeight.Bold

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/minigames/reaction/ReactionResultScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/minigames/reaction/ReactionResultScreen.kt
@@ -3,8 +3,10 @@ package at.aau.serg.websocketbrokerdemo.ui.theme.minigames.reaction
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
@@ -14,6 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -45,7 +49,18 @@ fun ReactionResultScreen(
     canFinishMinigame: Boolean,
     onContinueClick: () -> Unit
 ) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    // Cap height to the available window so the Continue button stays reachable
+    // (with 3-4 players the result rows would otherwise push it off-screen).
+    val screenHeight = with(LocalDensity.current) {
+        LocalWindowInfo.current.containerSize.height.toDp()
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .heightIn(max = screenHeight - 80.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
         Text(
             text = stringResource(R.string.reaction_result_title),
             color = ReactionResultStyle.titleColor,

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/minigames/reaction/ReactionRoundEndedScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/theme/minigames/reaction/ReactionRoundEndedScreen.kt
@@ -5,10 +5,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -29,8 +35,15 @@ private object ReactionRoundEndedStyle {
 fun ReactionRoundEndedScreen(
     results: List<ReactionPlayerUiState>
 ) {
+    val screenHeight = with(LocalDensity.current) {
+        LocalWindowInfo.current.containerSize.height.toDp()
+    }
+
     Column(
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .heightIn(max = screenHeight - 80.dp)
+            .verticalScroll(rememberScrollState())
     ) {
         Text(
             text = stringResource(R.string.reaction_round_ended_title),


### PR DESCRIPTION
**Beschreibung:**
## Überblick
Behebt ein Layout-Problem in den Minispiel-Ergebnis-Screens bei 3–4 Spielern und stellt die restlichen hartkodierten Anzeige-Texte auf Englisch um.

## Änderungen
- Minispiel-Result-Screens (Schätzspiel, Flaggenraten, Reaktionsspiel) auf die verfügbare Fensterhöhe begrenzt und scrollbar gemacht, damit der „Continue"-Button bei 3–4 Spielern erreichbar bleibt
- Reaktions-Runden-Ende-Screen ebenfalls scrollbar, wenn der Inhalt bei vielen Spielern überläuft
- Restliche deutsche Anzeige-Texte ins Englische übersetzt (GameScreen, MinigameOverlay)

## Tests
- Layout-Verhalten bei 3–4 Spielern manuell in der App zu verifizieren
